### PR TITLE
Rename HasValue to IsOk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,7 @@
 # Version `1.1.0-pre`
+
+- Rewrite and update a lot of documentation.
+
+- Rename `Result<T>.HasValue` to `IsOk`.
+
+- Add `Result<T>.IsError`.

--- a/src/Rascal.Tests/AsyncMappingTests.cs
+++ b/src/Rascal.Tests/AsyncMappingTests.cs
@@ -8,7 +8,7 @@ public class AsyncMappingTests
         var r = Ok(2);
         var x = await r.MapAsync(x => Task.FromResult(x.ToString()));
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe("2");
     }
 
@@ -18,7 +18,7 @@ public class AsyncMappingTests
         var r = Err<int>("error");
         var x = await r.MapAsync(x => Task.FromResult(x.ToString()));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -28,7 +28,7 @@ public class AsyncMappingTests
         var r = Ok(2);
         var x = await r.ThenAsync(x => Task.FromResult(Ok(x.ToString())));
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe("2");
     }
 
@@ -38,7 +38,7 @@ public class AsyncMappingTests
         var r = Ok(2);
         var x = await r.ThenAsync(_ => Task.FromResult(Err<string>("error")));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -48,7 +48,7 @@ public class AsyncMappingTests
         var r = Err<int>("error");
         var x = await r.ThenAsync(x => Task.FromResult(Ok(x.ToString())));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
     
@@ -58,7 +58,7 @@ public class AsyncMappingTests
         var r = Ok(2);
         var x = await r.TryMapAsync(x => Task.FromResult(x.ToString()));
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe("2");
     }
 
@@ -68,7 +68,7 @@ public class AsyncMappingTests
         var r = Err<int>("error");
         var x = r.TryMap(x => Task.FromResult(x.ToString()));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -78,7 +78,7 @@ public class AsyncMappingTests
         var r = Ok(2);
         var x = await r.TryMapAsync<string>(_ => throw new TestException());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         var e = x.error.ShouldBeOfType<ExceptionError>();
         e.Exception.ShouldBeOfType<TestException>();
     }
@@ -89,7 +89,7 @@ public class AsyncMappingTests
         var r = Err<int>("error");
         var x = await r.TryMapAsync<string>(_ => throw new TestException());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         var e = x.error.ShouldBeOfType<StringError>();
         e.Message.ShouldBe("error");
     }
@@ -100,7 +100,7 @@ public class AsyncMappingTests
         var r = Ok(2);
         var x = await r.ThenTryAsync(x => Task.FromResult(Ok(x.ToString())));
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe("2");
     }
 
@@ -110,7 +110,7 @@ public class AsyncMappingTests
         var r = Ok(2);
         var x = await r.ThenTryAsync(_ => Task.FromResult(Err<string>("error")));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -120,7 +120,7 @@ public class AsyncMappingTests
         var r = Err<int>("error");
         var x = await r.ThenTryAsync(x => Task.FromResult(Ok(x.ToString())));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -130,7 +130,7 @@ public class AsyncMappingTests
         var r = Ok(2);
         var x = await r.ThenTryAsync<string>(_ => throw new TestException());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         var e = x.error.ShouldBeOfType<ExceptionError>();
         e.Exception.ShouldBeOfType<TestException>();
     }
@@ -141,7 +141,7 @@ public class AsyncMappingTests
         var r = Err<int>("error");
         var x = await r.ThenTryAsync<string>(_ => throw new TestException());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         var e = x.error.ShouldBeOfType<StringError>();
         e.Message.ShouldBe("error");
     }

--- a/src/Rascal.Tests/MappingTests.cs
+++ b/src/Rascal.Tests/MappingTests.cs
@@ -8,7 +8,7 @@ public class MappingTests
         var r = Ok(2);
         var x = r.Map(x => x.ToString());
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe("2");
     }
 
@@ -18,7 +18,7 @@ public class MappingTests
         var r = Err<int>("error");
         var x = r.Map(x => x.ToString());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -28,7 +28,7 @@ public class MappingTests
         var r = Ok(2);
         var x = r.Then(x => Ok(x.ToString()));
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe("2");
     }
 
@@ -38,7 +38,7 @@ public class MappingTests
         var r = Ok(2);
         var x = r.Then(_ => Err<string>("error"));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -48,7 +48,7 @@ public class MappingTests
         var r = Err<int>("error");
         var x = r.Then(x => Ok(x.ToString()));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -60,7 +60,7 @@ public class MappingTests
             x => Ok(x.ToString()),
             (x, s) => (x, s));
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe((2, "2"));
     }
 
@@ -72,7 +72,7 @@ public class MappingTests
             x => Err<string>("error"),
             (x, s) => (x, s));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -84,7 +84,7 @@ public class MappingTests
             x => Ok(x.ToString()),
             (x, s) => (x, s));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -94,7 +94,7 @@ public class MappingTests
         var r = Ok(2);
         var x = r.TryMap(x => x.ToString());
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe("2");
     }
 
@@ -104,7 +104,7 @@ public class MappingTests
         var r = Err<int>("error");
         var x = r.TryMap(x => x.ToString());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -114,7 +114,7 @@ public class MappingTests
         var r = Ok(2);
         var x = r.TryMap<string>(_ => throw new TestException());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         var e = x.error.ShouldBeOfType<ExceptionError>();
         e.Exception.ShouldBeOfType<TestException>();
     }
@@ -125,7 +125,7 @@ public class MappingTests
         var r = Err<int>("error");
         var x = r.TryMap<string>(_ => throw new TestException());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         var e = x.error.ShouldBeOfType<StringError>();
         e.Message.ShouldBe("error");
     }
@@ -136,7 +136,7 @@ public class MappingTests
         var r = Ok(2);
         var x = r.ThenTry(x => Ok(x.ToString()));
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe("2");
     }
 
@@ -146,7 +146,7 @@ public class MappingTests
         var r = Ok(2);
         var x = r.ThenTry(_ => Err<string>("error"));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -156,7 +156,7 @@ public class MappingTests
         var r = Err<int>("error");
         var x = r.ThenTry(x => Ok(x.ToString()));
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error?.Message.ShouldBe("error");
     }
 
@@ -166,7 +166,7 @@ public class MappingTests
         var r = Ok(2);
         var x = r.ThenTry<string>(_ => throw new TestException());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         var e = x.error.ShouldBeOfType<ExceptionError>();
         e.Exception.ShouldBeOfType<TestException>();
     }
@@ -177,7 +177,7 @@ public class MappingTests
         var r = Err<int>("error");
         var x = r.ThenTry<string>(_ => throw new TestException());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         var e = x.error.ShouldBeOfType<StringError>();
         e.Message.ShouldBe("error");
     }
@@ -188,7 +188,7 @@ public class MappingTests
         var r = Ok(2);
         var x = r.MapError(_ => new TestError());
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe(2);
     }
 
@@ -198,7 +198,7 @@ public class MappingTests
         var r = Err<int>("error");
         var x = r.MapError(_ => new TestError());
 
-        x.HasValue.ShouldBeFalse();
+        x.IsOk.ShouldBeFalse();
         x.error.ShouldBeOfType<TestError>();
     }
 }

--- a/src/Rascal.Tests/PreludeTests.cs
+++ b/src/Rascal.Tests/PreludeTests.cs
@@ -9,7 +9,7 @@ public class PreludeTests
     {
         var r = Ok(2);
 
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe(2);
     }
 
@@ -18,7 +18,7 @@ public class PreludeTests
     {
         var r = Err<int>("error");
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldBe("error");
     }
 
@@ -27,7 +27,7 @@ public class PreludeTests
     {
         var r = ParseR<int>("123", CultureInfo.InvariantCulture);
         
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe(123);
     }
 
@@ -36,7 +36,7 @@ public class PreludeTests
     {
         var r = ParseR<int>("24a", CultureInfo.InvariantCulture);
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error.ShouldNotBeNull();
     }
 
@@ -46,7 +46,7 @@ public class PreludeTests
         var s = "123".AsSpan();
         var r = ParseR<int>(s, CultureInfo.InvariantCulture);
         
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe(123);
     }
 
@@ -56,7 +56,7 @@ public class PreludeTests
         var s = "24a".AsSpan();
         var r = ParseR<int>(s, CultureInfo.InvariantCulture);
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error.ShouldNotBeNull();
     }
 
@@ -65,7 +65,7 @@ public class PreludeTests
     {
         var r = Try(() => 2);
 
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe(2);
     }
 
@@ -74,7 +74,7 @@ public class PreludeTests
     {
         var r = Try<int>(() => throw new TestException());
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         var e = r.error.ShouldBeOfType<ExceptionError>();
         e.Exception.ShouldBeOfType<TestException>();
     }

--- a/src/Rascal.Tests/ResultExtensionsTests.cs
+++ b/src/Rascal.Tests/ResultExtensionsTests.cs
@@ -8,7 +8,7 @@ public class ResultExtensionsTests
         var r = Ok(Ok(2));
         var x = r.Unnest();
 
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
         x.value.ShouldBe(2);
     }
 
@@ -18,7 +18,7 @@ public class ResultExtensionsTests
         var x = "uwu";
         var r = x.NotNull("error");
 
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe("uwu");
     }
 
@@ -28,7 +28,7 @@ public class ResultExtensionsTests
         var x = null as string;
         var r = x.NotNull("error");
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldBe("error");
     }
 
@@ -38,7 +38,7 @@ public class ResultExtensionsTests
         var x = 2 as int?;
         var r = x.NotNull("error");
 
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe(2);
     }
 
@@ -48,7 +48,7 @@ public class ResultExtensionsTests
         var x = null as int?;
         var r = x.NotNull("error");
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldBe("error");
     }
 
@@ -77,7 +77,7 @@ public class ResultExtensionsTests
 
         var result = xs.Sequence();
         
-        result.HasValue.ShouldBeTrue();
+        result.IsOk.ShouldBeTrue();
         result.value.ShouldBe([1, 2, 3, 4, 5]);
     }
 
@@ -88,7 +88,7 @@ public class ResultExtensionsTests
 
         var result = xs.Sequence();
 
-        result.HasValue.ShouldBeFalse();
+        result.IsOk.ShouldBeFalse();
         result.error?.Message.ShouldBe("error 1");
     }
 
@@ -99,7 +99,7 @@ public class ResultExtensionsTests
 
         var result = xs.Sequence();
 
-        result.HasValue.ShouldBeTrue();
+        result.IsOk.ShouldBeTrue();
         result.value.ShouldBeEmpty();
     }
 
@@ -109,7 +109,7 @@ public class ResultExtensionsTests
         var dict = new Dictionary<string, int>() { ["a"] = 2 };
         var r = dict.TryGetValueR("a", "error");
 
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe(2);
     }
 
@@ -119,7 +119,7 @@ public class ResultExtensionsTests
         var dict = new Dictionary<string, int>();
         var r = dict.TryGetValueR("a", "error");
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldBe("error");
     }
 
@@ -129,7 +129,7 @@ public class ResultExtensionsTests
         var xs = new[] { 2 };
         var r = xs.Index(0, "error");
 
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe(2);
     }
 
@@ -139,7 +139,7 @@ public class ResultExtensionsTests
         var xs = Array.Empty<int>();
         var r = xs.Index(0, "error");
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldBe("error");
     }
 
@@ -148,7 +148,7 @@ public class ResultExtensionsTests
     {
         var r = await Task.FromResult(2).CatchCancellation();
 
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe(2);
     }
 
@@ -161,7 +161,7 @@ public class ResultExtensionsTests
         await cts.CancelAsync();
         var r = await task.CatchCancellation();
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error.ShouldBeOfType<CancellationError>();
         return;
 

--- a/src/Rascal.Tests/ResultTests.cs
+++ b/src/Rascal.Tests/ResultTests.cs
@@ -8,6 +8,7 @@ public class ResultTests
         var r = new Result<int>(2);
         
         r.IsOk.ShouldBeTrue();
+        r.IsError.ShouldBeFalse();
         r.value.ShouldBe(2);
         r.error.ShouldBeNull();
     }
@@ -18,6 +19,7 @@ public class ResultTests
         var r = new Result<int>(new TestError());
 
         r.IsOk.ShouldBeFalse();
+        r.IsError.ShouldBeTrue();
         r.value.ShouldBe(default);
         r.error.ShouldBeOfType<TestError>();
     }
@@ -28,6 +30,7 @@ public class ResultTests
         var r = default(Result<int>);
 
         r.IsOk.ShouldBeFalse();
+        r.IsError.ShouldBeTrue();
         r.value.ShouldBe(default);
         r.error.ShouldBe(default);
         r.Error.ShouldBe(Error.DefaultValueError);

--- a/src/Rascal.Tests/ResultTests.cs
+++ b/src/Rascal.Tests/ResultTests.cs
@@ -7,7 +7,7 @@ public class ResultTests
     {
         var r = new Result<int>(2);
         
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe(2);
         r.error.ShouldBeNull();
     }
@@ -17,7 +17,7 @@ public class ResultTests
     {
         var r = new Result<int>(new TestError());
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.value.ShouldBe(default);
         r.error.ShouldBeOfType<TestError>();
     }
@@ -27,7 +27,7 @@ public class ResultTests
     {
         var r = default(Result<int>);
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.value.ShouldBe(default);
         r.error.ShouldBe(default);
         r.Error.ShouldBe(Error.DefaultValueError);

--- a/src/Rascal.Tests/UtilityTests.cs
+++ b/src/Rascal.Tests/UtilityTests.cs
@@ -10,7 +10,7 @@ public class UtilityTests
         Result<int> x = 2;
 
         x.value.ShouldBe(2);
-        x.HasValue.ShouldBeTrue();
+        x.IsOk.ShouldBeTrue();
     }
 
     [Fact]
@@ -20,7 +20,7 @@ public class UtilityTests
         var b = Ok("uwu");
         var r = a.Combine(b);
 
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe((2, "uwu"));
     }
 
@@ -31,7 +31,7 @@ public class UtilityTests
         var b = Err<string>("error");
         var r = a.Combine(b);
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldBe("error");
     }
 
@@ -42,7 +42,7 @@ public class UtilityTests
         var b = Ok("uwu");
         var r = a.Combine(b);
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldBe("error");
     }
 
@@ -53,7 +53,7 @@ public class UtilityTests
         var b = Err<string>("error b");
         var r = a.Combine(b);
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         var error = r.error.ShouldBeOfType<AggregateError>();
         error.Errors.Select(x => x.Message).ShouldBe(["error a", "error b"]);
     }
@@ -63,7 +63,7 @@ public class UtilityTests
     {
         var r = Ok<object>("uwu").ToType<string>();
 
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe("uwu");
     }
 
@@ -72,7 +72,7 @@ public class UtilityTests
     {
         var r = Ok<object>("uwu").ToType<int>();
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldNotBeNull();
     }
 
@@ -81,7 +81,7 @@ public class UtilityTests
     {
         var r = Err<object>("error").ToType<int>();
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldBe("error");
     }
 
@@ -90,7 +90,7 @@ public class UtilityTests
     {
         var r = Ok(2).Validate(_ => false);
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldNotBeNull();
     }
 
@@ -99,7 +99,7 @@ public class UtilityTests
     {
         var r = Ok(2).Validate(_ => false, _ => "error");
         
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldBe("error");
     }
     
@@ -108,7 +108,7 @@ public class UtilityTests
     {
         var r = Ok(2).Validate(_ => true, _ => "error");
 
-        r.HasValue.ShouldBeTrue();
+        r.IsOk.ShouldBeTrue();
         r.value.ShouldBe(2);
     }
 
@@ -117,7 +117,7 @@ public class UtilityTests
     {
         var r = Err<int>("error a").Validate(_ => false, _ => "error b");
 
-        r.HasValue.ShouldBeFalse();
+        r.IsOk.ShouldBeFalse();
         r.error?.Message.ShouldBe("error a");
     }
 

--- a/src/Rascal/Error.cs
+++ b/src/Rascal/Error.cs
@@ -1,8 +1,17 @@
 namespace Rascal;
 
 /// <summary>
-/// An abstract error.
+/// An error containing a simple message.
+/// Makes up the other half of a <see cref="Result{T}"/> which might be an error.
 /// </summary>
+/// <remarks>
+/// An error is conceptually akin to an exception but without the ability to be thrown,
+/// meant to be a more lightweight type meant to be wrapped in a <see cref="Result{T}"/>.
+/// An error fundamentally only contains a single string message, however other more concrete types such as
+/// <see cref="ExceptionError"/> or <see cref="AggregateError"/> may define other properties.
+/// Errors are meant to be small, specific, and descriptive, such that they are easy to match over
+/// and provide specific handling for specific kinds of errors.
+/// </remarks>
 public abstract class Error
 {
     /// <summary>

--- a/src/Rascal/Prelude.cs
+++ b/src/Rascal/Prelude.cs
@@ -10,10 +10,10 @@ namespace Rascal;
 public static class Prelude
 {
     /// <summary>
-    /// Creates a result containing a value.
+    /// Creates a result containing an ok value.
     /// </summary>
-    /// <typeparam name="T">The type of the value in the result.</typeparam>
-    /// <param name="value">The value to create the result from.</param>
+    /// <typeparam name="T">The type of the ok value.</typeparam>
+    /// <param name="value">The ok value to create the result from.</param>
     [Pure]
     public static Result<T> Ok<T>(T value) =>
         new(value);
@@ -21,7 +21,7 @@ public static class Prelude
     /// <summary>
     /// Creates a result containing an error.
     /// </summary>
-    /// <typeparam name="T">The type of the value in the result.</typeparam>
+    /// <typeparam name="T">The type of an ok value in the result.</typeparam>
     /// <param name="error">The error to create the result from.</param>
     [Pure]
     public static Result<T> Err<T>(Error error) =>

--- a/src/Rascal/Result.cs
+++ b/src/Rascal/Result.cs
@@ -3,9 +3,9 @@
 namespace Rascal;
 
 /// <summary>
-/// A type which contains either a successful value or an error.
+/// A type which contains either an ok value or an error.
 /// </summary>
-/// <typeparam name="T">The type of a successful value.</typeparam>
+/// <typeparam name="T">The type of an ok value.</typeparam>
 [DebuggerTypeProxy(typeof(ResultDebugProxy<>))]
 public readonly partial struct Result<T>
 {
@@ -15,14 +15,14 @@ public readonly partial struct Result<T>
     internal Error Error => error ?? Error.DefaultValueError;
 
     /// <summary>
-    /// Whether the result has a value or not.
+    /// Whether the result has an ok value or not.
     /// </summary>
     public bool IsOk { get; }
 
     /// <summary>
-    /// Creates a new result with a successful value.
+    /// Creates a new result with an ok value.
     /// </summary>
-    /// <param name="value">The successful value.</param>
+    /// <param name="value">The ok value.</param>
     public Result(T value)
     {
         IsOk = true;

--- a/src/Rascal/Result.cs
+++ b/src/Rascal/Result.cs
@@ -12,6 +12,11 @@ public readonly partial struct Result<T>
     internal readonly T? value;
     internal readonly Error? error;
 
+    /// <summary>
+    /// Same as <see cref="error"/> but returns <see cref="Error.DefaultValueError"/>
+    /// in case <see cref="error"/> is null. This is primarily meant as a fail-safe in case
+    /// the result is <see langword="default"/>.
+    /// </summary>
     internal Error Error => error ?? Error.DefaultValueError;
 
     /// <summary>

--- a/src/Rascal/Result.cs
+++ b/src/Rascal/Result.cs
@@ -15,9 +15,17 @@ public readonly partial struct Result<T>
     internal Error Error => error ?? Error.DefaultValueError;
 
     /// <summary>
-    /// Whether the result has an ok value or not.
+    /// Whether the result is ok.
     /// </summary>
     public bool IsOk { get; }
+
+    /// <summary>
+    /// Whether the result is an error.
+    /// </summary>
+    /// <remarks>
+    /// This is always the inverse of <see cref="IsOk"/> but is more specific about intent.
+    /// </remarks>
+    public bool IsError => !IsOk;
 
     /// <summary>
     /// Creates a new result with an ok value.

--- a/src/Rascal/Result.cs
+++ b/src/Rascal/Result.cs
@@ -17,7 +17,7 @@ public readonly partial struct Result<T>
     /// <summary>
     /// Whether the result has a value or not.
     /// </summary>
-    public bool HasValue { get; }
+    public bool IsOk { get; }
 
     /// <summary>
     /// Creates a new result with a successful value.
@@ -25,7 +25,7 @@ public readonly partial struct Result<T>
     /// <param name="value">The successful value.</param>
     public Result(T value)
     {
-        HasValue = true;
+        IsOk = true;
         this.value = value;
         error = null;
     }
@@ -36,7 +36,7 @@ public readonly partial struct Result<T>
     /// <param name="error">The error of the result.</param>
     public Result(Error error)
     {
-        HasValue = false;
+        IsOk = false;
         value = default;
         this.error = error;
     }
@@ -46,7 +46,7 @@ public readonly partial struct Result<T>
     /// </summary>
     [Pure]
     public override string ToString() =>
-        HasValue
+        IsOk
             ? $"Ok {{ {value} }}"
             : $"Error {{ {Error.Message} }}";
 }

--- a/src/Rascal/ResultDebugProxy.cs
+++ b/src/Rascal/ResultDebugProxy.cs
@@ -2,9 +2,9 @@ namespace Rascal;
 
 internal sealed class ResultDebugProxy<T>(Result<T> result)
 {
-    public bool HasValue { get; } = result.HasValue;
+    public bool IsOk { get; } = result.IsOk;
 
-    public object? Value { get; } = result.HasValue
+    public object? Value { get; } = result.IsOk
         ? result.value!
         : result.Error;
 }

--- a/src/Rascal/ResultExtensions.cs
+++ b/src/Rascal/ResultExtensions.cs
@@ -1,7 +1,7 @@
 namespace Rascal;
 
 /// <summary>
-/// Class containing extensions for or relating to <see cref="Result{T}"/>.
+/// Extensions for or relating to <see cref="Result{T}"/>.
 /// </summary>
 public static class ResultExtensions
 {
@@ -12,14 +12,14 @@ public static class ResultExtensions
     /// This operation is the same as applying <see cref="Result{T}.Then{TNew}"/>
     /// with the identity function, eg. <c>r.Then(x => x)</c>.
     /// </remarks>
-    /// <typeparam name="T">The type of the value in the result.</typeparam>
+    /// <typeparam name="T">The type of the ok value in the result.</typeparam>
     /// <param name="result">The result to un-nest.</param>
     [Pure]
     public static Result<T> Unnest<T>(this Result<Result<T>> result) =>
         result.Then(x => x);
 
     /// <summary>
-    /// Turns a nullable value into a result containing a non-null value
+    /// Turns a nullable value into a result containing a non-null ok value
     /// or an error if the value is <see langword="null"/>.
     /// </summary>
     /// <remarks>
@@ -47,32 +47,32 @@ public static class ResultExtensions
             : new(error ?? new NullError("Value was null."));
 
     /// <summary>
-    /// Gets the value within the result,
-    /// or <see langword="null"/> if the result does not contain a value.
+    /// Gets the ok value of the result,
+    /// or <see langword="null"/> if the result is an error.
     /// </summary>
     /// <remarks>
     /// This method differs from <see cref="Result{T}.GetValueOrDefault()"/> in that
     /// it specifically targets value types and returns <see langword="null"/> as opposed
-    /// to the default value for the type in case the result does not contain a value.
+    /// to the default value for the type in case the result is an error.
     /// Can also be understood as mapping the value to <c>T?</c> and calling
     /// <see cref="Result{T}.GetValueOrDefault()"/> on the returned result.
     /// </remarks>
-    /// <typeparam name="T">The type of the value in the result.</typeparam>
-    /// <param name="result">The result to get the value in.</param>
-    /// <returns>The value contained in <paramref name="result"/>,
-    /// or <see langword="null"/> if <paramref name="result"/> does not contain a value.</returns>
+    /// <typeparam name="T">The type of the ok value of the result.</typeparam>
+    /// <param name="result">The result to get the ok value of.</param>
+    /// <returns>The ok value of <paramref name="result"/>,
+    /// or <see langword="null"/> if <paramref name="result"/> is an error.</returns>
     [Pure]
     public static T? GetValueOrNull<T>(this Result<T> result) where T : struct =>
         result.Map(x => (T?)x).GetValueOrDefault();
 
     /// <summary>
-    /// Turns a sequence of results into a single result containing the values in the sequence
-    /// only if all the results have a value.
+    /// Turns a sequence of results into a single result containing the ok values in the results
+    /// only if all the results are ok.
     /// Can also been seen as turning an <c>IEnumerable&lt;Result&lt;T&gt;&gt;</c> "inside out".
     /// </summary>
     /// <param name="results">The results to turn into a single sequence.</param>
-    /// <typeparam name="T">The type of the values in the results.</typeparam>
-    /// <returns>A single result containing a sequence of all the values from the original sequence of results,
+    /// <typeparam name="T">The type of the ok values in the results.</typeparam>
+    /// <returns>A single result containing a sequence of all the ok values from the original sequence of results,
     /// or the first error encountered within the sequence.</returns>
     /// <remarks>
     /// This method completely enumerates the input sequence before returning and is not lazy.
@@ -97,7 +97,7 @@ public static class ResultExtensions
     /// or an error if the key is not present.
     /// </summary>
     /// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
-    /// <typeparam name="TValue">The type of values in the  dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
     /// <param name="dict">The dictionary to try locate the key in.</param>
     /// <param name="key">The key to locate.</param>
     /// <param name="error">The error to return if the key is not present.</param>
@@ -130,7 +130,7 @@ public static class ResultExtensions
                    $"which has a count of {list.Count}."));
 
     /// <summary>
-    /// Catches the cancellation of a task and wraps the value or exception in a result.
+    /// Catches the cancellation of a task and wraps the returned value or thrown exception in a result.
     /// </summary>
     /// <param name="task">The task to catch.</param>
     /// <param name="error">A function which produces an error in case of a cancellation.</param>

--- a/src/Rascal/Result_Equality.cs
+++ b/src/Rascal/Result_Equality.cs
@@ -15,7 +15,7 @@ public readonly partial struct Result<T> :
     /// <param name="other">The value to check for equality with the value in the result.</param>
     [Pure]
     public bool Equals(T? other) =>
-        HasValue && (other?.Equals(value) ?? value is null);
+        IsOk && (other?.Equals(value) ?? value is null);
 
     /// <summary>
     /// Checks whether the result is equal to another result.
@@ -25,8 +25,8 @@ public readonly partial struct Result<T> :
     /// <param name="other">The result to check for equality with the current result.</param>
     [Pure]
     public bool Equals(Result<T> other) =>
-        HasValue && other.HasValue && (other.value?.Equals(value) ?? value is null) ||
-        !HasValue && !other.HasValue;
+        IsOk && other.IsOk && (other.value?.Equals(value) ?? value is null) ||
+        !IsOk && !other.IsOk;
 
     /// <inheritdoc/>
     [Pure]
@@ -37,7 +37,7 @@ public readonly partial struct Result<T> :
     /// <inheritdoc/>
     [Pure]
     public override int GetHashCode() =>
-        HasValue
+        IsOk
             ? value?.GetHashCode() ?? 0
             : 0;
 

--- a/src/Rascal/Result_Equality.cs
+++ b/src/Rascal/Result_Equality.cs
@@ -10,16 +10,16 @@ public readonly partial struct Result<T> :
 #endif
 {
     /// <summary>
-    /// Checks whether the result has a value and the value is equal to another value.
+    /// Checks whether the result is ok and the ok value is equal to another value.
     /// </summary>
-    /// <param name="other">The value to check for equality with the value in the result.</param>
+    /// <param name="other">The value to check for equality with the ok value of the result.</param>
     [Pure]
     public bool Equals(T? other) =>
         IsOk && (other?.Equals(value) ?? value is null);
 
     /// <summary>
     /// Checks whether the result is equal to another result.
-    /// Results are equal if both results have values which are equal,
+    /// Results are equal if both results are ok and the ok values are equal,
     /// or if both results are errors.
     /// </summary>
     /// <param name="other">The result to check for equality with the current result.</param>
@@ -43,7 +43,7 @@ public readonly partial struct Result<T> :
 
     /// <summary>
     /// Checks whether two results are equal.
-    /// Results are equal if both results have values which are equal,
+    /// Results are equal if both results are ok and the ok values are equal,
     /// or if both results are errors.
     /// </summary>
     /// <param name="a">The first result to compare.</param>
@@ -54,7 +54,7 @@ public readonly partial struct Result<T> :
     
     /// <summary>
     /// Checks whether two results are not equal.
-    /// Results are equal if both results have values which are equal,
+    /// Results are equal if both results are ok and the ok values are equal,
     /// or if both results are errors.
     /// </summary>
     /// <param name="a">The first result to compare.</param>
@@ -64,10 +64,10 @@ public readonly partial struct Result<T> :
         !a.Equals(b);
 
     /// <summary>
-    /// Checks whether a result has a value and the value is equal to another value.
+    /// Checks whether a result is ok and the ok value is equal to another value.
     /// </summary>
     /// <param name="a">The result to compare.</param>
-    /// <param name="b">The value to check for equality with the value in the result.</param>
+    /// <param name="b">The value to check for equality with the ok value in the result.</param>
     [Pure]
     public static bool operator ==(Result<T> a, T? b) =>
         a.Equals(b);
@@ -76,7 +76,7 @@ public readonly partial struct Result<T> :
     /// Checks whether a result either does not have a value, or the value is not equal to another value.
     /// </summary>
     /// <param name="a">The result to compare.</param>
-    /// <param name="b">The value to check for inequality with the value in the result.</param>
+    /// <param name="b">The value to check for inequality with the ok value in the result.</param>
     [Pure]
     public static bool operator !=(Result<T> a, T? b) =>
         !a.Equals(b);

--- a/src/Rascal/Result_Mapping.cs
+++ b/src/Rascal/Result_Mapping.cs
@@ -12,7 +12,7 @@ public readonly partial struct Result<T>
     /// or the error of the original result.</returns>
     [Pure]
     public Result<TNew> Map<TNew>(Func<T, TNew> mapping) =>
-        HasValue
+        IsOk
             ? new(mapping(value!))
             : new(Error);
 
@@ -26,7 +26,7 @@ public readonly partial struct Result<T>
     /// or a new result containing the error of the original result.</returns>
     [Pure]
     public Result<TNew> Then<TNew>(Func<T, Result<TNew>> mapping) =>
-        HasValue
+        IsOk
             ? mapping(value!)
             : new(Error);
 
@@ -62,11 +62,11 @@ public readonly partial struct Result<T>
         Func<T, Result<TOther>> other,
         Func<T, TOther, TNew> mapping)
     {
-        if (!HasValue) return new(Error);
+        if (!IsOk) return new(Error);
         var a = value;
 
         var br = other(a!);
-        if (!br.HasValue) return new(br.Error);
+        if (!br.IsOk) return new(br.Error);
         var b = br.value;
 
         return new(mapping(a!, b!));
@@ -130,7 +130,7 @@ public readonly partial struct Result<T>
     /// or the value of the original result.</returns>
     [Pure]
     public Result<T> MapError(Func<Error, Error> mapping) =>
-        !HasValue
+        !IsOk
             ? new(mapping(Error))
             : this;
 }

--- a/src/Rascal/Result_Mapping.cs
+++ b/src/Rascal/Result_Mapping.cs
@@ -3,12 +3,12 @@ namespace Rascal;
 public readonly partial struct Result<T>
 {
     /// <summary>
-    /// Maps the value of the result using a mapping function,
-    /// or does nothing if the result is an error.  
+    /// Maps the ok value of the result using a mapping function,
+    /// or does nothing if the result is an error.
     /// </summary>
-    /// <param name="mapping">The function used to map the value.</param>
+    /// <param name="mapping">The function used to map the ok value.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
-    /// <returns>A new result containing either the mapped value
+    /// <returns>A new result containing either the mapped ok value
     /// or the error of the original result.</returns>
     [Pure]
     public Result<TNew> Map<TNew>(Func<T, TNew> mapping) =>
@@ -17,10 +17,10 @@ public readonly partial struct Result<T>
             : new(Error);
 
     /// <summary>
-    /// Maps the value of the result to a new result using a mapping function,
+    /// Maps the ok value of the result to a new result using a mapping function,
     /// or does nothing if the result is an error.
     /// </summary>
-    /// <param name="mapping">The function used to map the value to a new result.</param>
+    /// <param name="mapping">The function used to map the ok value to a new result.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
     /// <returns>A result which is either the mapped result
     /// or a new result containing the error of the original result.</returns>
@@ -41,21 +41,22 @@ public readonly partial struct Result<T>
         Then(mapping);
 
     /// <summary>
-    /// Maps the value of the result to an intermediate result using a mapping function,
-    /// then applies another mapping function onto the values of the original and intermediate results,
+    /// Maps the ok value of the result to an intermediate result using a mapping function,
+    /// then applies another mapping function onto the ok values of the original and intermediate results,
     /// or does nothing if either of the results is an error.
     /// </summary>
     /// <remarks>
     /// The expression <c>r.SelectMany(x => f(x), (x, y) => g(x, y))</c> can be written as
     /// <c>r.Bind(x => f(x).Map(y => g(x, y)))</c>.
     /// </remarks>
-    /// <param name="other">The function used to map the value to an intermediate result.</param>
-    /// <param name="mapping">The function used to map the value to a new result.</param>
+    /// <param name="other">The function used to map the ok value to an intermediate result.</param>
+    /// <param name="mapping">The function used to map the ok value
+    /// and ok value of the intermediate result to a new result.</param>
     /// <typeparam name="TOther">The type of the intermediate value.</typeparam>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
     /// <returns>A result constructed by applying <paramref name="mapping"/>
-    /// onto the value contained in the result returned by <paramref name="other"/>
-    /// as well as the value in the original result,
+    /// onto the ok value contained in the result returned by <paramref name="other"/>
+    /// as well as the ok value in the original result,
     /// or a new result containing the error of the original or intermediate results.</returns>
     [Pure]
     public Result<TNew> SelectMany<TOther, TNew>(
@@ -73,12 +74,12 @@ public readonly partial struct Result<T>
     }
 
     /// <summary>
-    /// Tries to map the value of the result using a mapping function,
+    /// Tries to map the ok value of the result using a mapping function,
     /// or does nothing if the result is an error.
     /// If the mapping function throws an exception, the exception will be returned wrapped in an
     /// <see cref="ExceptionError"/>.
     /// </summary>
-    /// <param name="mapping">The function used to map the value.</param>
+    /// <param name="mapping">The function used to map the ok value.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
     /// <returns>A new result containing either the mapped value,
     /// the exception thrown by <paramref name="mapping"/> wrapped in an <see cref="ExceptionError"/>,
@@ -97,12 +98,12 @@ public readonly partial struct Result<T>
     }
 
     /// <summary>
-    /// Tries to map the value of the result to a new result using a mapping function,
+    /// Tries to map the ok value of the result to a new result using a mapping function,
     /// or does nothing if the result is an error.
     /// If the mapping function throws an exception, the exception will be returned wrapped in an
     /// <see cref="ExceptionError"/>.
     /// </summary>
-    /// <param name="mapping">The function used to map the value to a new result.</param>
+    /// <param name="mapping">The function used to map the ok value to a new result.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
     /// <returns>A result which is either the mapped result,
     /// the exception thrown by <paramref name="mapping"/> wrapped in an <see cref="ExceptionError"/>,
@@ -121,13 +122,13 @@ public readonly partial struct Result<T>
     }
 
     /// <summary>
-    /// Maps the error in the result if it contains one
+    /// Maps the error in the result if it is an error
     /// and returns a new result containing the mapped error.
     /// Otherwise, returns the current result.
     /// </summary>
     /// <param name="mapping">The function used to map the error.</param>
     /// <returns>A result which contains either the mapped error
-    /// or the value of the original result.</returns>
+    /// or the ok value of the original result.</returns>
     [Pure]
     public Result<T> MapError(Func<Error, Error> mapping) =>
         !IsOk

--- a/src/Rascal/Result_Mapping_Async.cs
+++ b/src/Rascal/Result_Mapping_Async.cs
@@ -18,7 +18,7 @@ public readonly partial struct Result<T>
     [Pure]
     public ValueTask<Result<TNew>> MapAsync<TNew>(Func<T, Task<TNew>> mapping)
     {
-        if (!HasValue) return new(new Result<TNew>(Error));
+        if (!IsOk) return new(new Result<TNew>(Error));
 
         var task = mapping(value!);
         return new(CreateResult(task));
@@ -43,7 +43,7 @@ public readonly partial struct Result<T>
     [Pure]
     public ValueTask<Result<TNew>> ThenAsync<TNew>(Func<T, Task<Result<TNew>>> mapping)
     {
-        if (!HasValue) return new(new Result<TNew>(Error));
+        if (!IsOk) return new(new Result<TNew>(Error));
 
         var task = mapping(value!);
         return new(task);
@@ -66,7 +66,7 @@ public readonly partial struct Result<T>
     [Pure]
     public ValueTask<Result<TNew>> TryMapAsync<TNew>(Func<T, Task<TNew>> mapping)
     {
-        if (!HasValue) return new(new Result<TNew>(Error));
+        if (!IsOk) return new(new Result<TNew>(Error));
 
         try
         {
@@ -109,7 +109,7 @@ public readonly partial struct Result<T>
     [Pure]
     public ValueTask<Result<TNew>> ThenTryAsync<TNew>(Func<T, Task<Result<TNew>>> mapping)
     {
-        if (!HasValue) return new(new Result<TNew>(Error));
+        if (!IsOk) return new(new Result<TNew>(Error));
 
         try
         {
@@ -134,7 +134,7 @@ public readonly partial struct Result<T>
     /// or the error of the original result.</returns>
     [Pure]
     public async Task<Result<TNew>> MapAsync<TNew>(Func<T, Task<TNew>> mapping) =>
-        HasValue
+        IsOk
             ? new(await mapping(value!))
             : new(Error);
 
@@ -148,7 +148,7 @@ public readonly partial struct Result<T>
     /// or a new result containing the error of the original result.</returns>
     [Pure]
     public async Task<Result<TNew>> ThenAsync<TNew>(Func<T, Task<Result<TNew>>> mapping) =>
-        HasValue
+        IsOk
             ? await mapping(value!)
             : new(Error);
 
@@ -166,7 +166,7 @@ public readonly partial struct Result<T>
     [Pure]
     public async Task<Result<TNew>> TryMapAsync<TNew>(Func<T, Task<TNew>> mapping)
     {
-        if (!HasValue) return new(Error);
+        if (!IsOk) return new(Error);
 
         try
         {
@@ -193,7 +193,7 @@ public readonly partial struct Result<T>
     [Pure]
     public async Task<Result<TNew>> ThenTryAsync<TNew>(Func<T, Task<Result<TNew>>> mapping)
     {
-        if (!HasValue) return new Result<TNew>(Error);
+        if (!IsOk) return new Result<TNew>(Error);
 
         try
         {

--- a/src/Rascal/Result_Mapping_Async.cs
+++ b/src/Rascal/Result_Mapping_Async.cs
@@ -6,13 +6,13 @@ public readonly partial struct Result<T>
 #if NETCOREAPP
 
     /// <summary>
-    /// Maps the value of the result using an asynchronous mapping function,
+    /// Maps the ok value of the result using an asynchronous mapping function,
     /// or does nothing if the result is an error.
     /// </summary>
-    /// <param name="mapping">The function used to map the value.</param>
+    /// <param name="mapping">The function used to map the ok value.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
     /// <returns>A <see cref="ValueTask{T}"/> which either completes asynchronously
-    /// by invoking the mapping function on the value of the result and constructing a new result
+    /// by invoking the mapping function on the ok value of the result and constructing a new result
     /// containing the mapped value, or completes synchronously by returning a new result
     /// containing the error of the original result.</returns>
     [Pure]
@@ -31,13 +31,13 @@ public readonly partial struct Result<T>
     }
     
     /// <summary>
-    /// Maps the value of the result to a new result using an asynchronous mapping function,
+    /// Maps the ok value of the result to a new result using an asynchronous mapping function,
     /// or does nothing if the result is an error.
     /// </summary>
-    /// <param name="mapping">The function used to map the value to a new result.</param>
+    /// <param name="mapping">The function used to map the ok value to a new result.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
     /// <returns>A <see cref="ValueTask{T}"/> which either completes asynchronously
-    /// by invoking the mapping function on the value of the result, 
+    /// by invoking the mapping function on the ok value of the result, 
     /// or completes synchronously by returning a new result
     /// containing the error of the original result.</returns>
     [Pure]
@@ -50,15 +50,15 @@ public readonly partial struct Result<T>
     }
     
     /// <summary>
-    /// Maps the value of the result using an asynchronous mapping function,
+    /// Maps the ok value of the result using an asynchronous mapping function,
     /// or does nothing if the result is an error.
     /// If the mapping function throws an exception, the exception will be returned wrapped in an
     /// <see cref="ExceptionError"/>.
     /// </summary>
-    /// <param name="mapping">The function used to map the value.</param>
+    /// <param name="mapping">The function used to map the ok value.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
     /// <returns>A <see cref="ValueTask{T}"/> which either completes asynchronously
-    /// by invoking the mapping function on the value of the result and constructing a new result
+    /// by invoking the mapping function on the ok value of the result and constructing a new result
     /// containing the mapped value,
     /// returning any exception thrown by <paramref name="mapping"/>
     /// wrapped in an <see cref="ExceptionError"/>,
@@ -93,15 +93,15 @@ public readonly partial struct Result<T>
     }
     
     /// <summary>
-    /// Maps the value of the result to a new result using an asynchronous mapping function,
+    /// Maps the ok value of the result to a new result using an asynchronous mapping function,
     /// or does nothing if the result is an error.
     /// If the mapping function throws an exception, the exception will be returned wrapped in an
     /// <see cref="ExceptionError"/>.
     /// </summary>
-    /// <param name="mapping">The function used to map the value to a new result.</param>
+    /// <param name="mapping">The function used to map the ok value to a new result.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
     /// <returns>A <see cref="ValueTask{T}"/> which either completes asynchronously
-    /// by invoking the mapping function on the value of the result,
+    /// by invoking the mapping function on the ok value of the result,
     /// returning any exception thrown by <paramref name="mapping"/>
     /// wrapped in an <see cref="ExceptionError"/>,
     /// or completes synchronously by returning a new result
@@ -125,12 +125,12 @@ public readonly partial struct Result<T>
 #else
     
     /// <summary>
-    /// Maps the value of the result using an asynchronous mapping function,
+    /// Maps the ok value of the result using an asynchronous mapping function,
     /// or does nothing if the result is an error.
     /// </summary>
-    /// <param name="mapping">The function used to map the value.</param>
+    /// <param name="mapping">The function used to map the ok value.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
-    /// <returns>A new result containing either the mapped value
+    /// <returns>A new result containing either the mapped ok value
     /// or the error of the original result.</returns>
     [Pure]
     public async Task<Result<TNew>> MapAsync<TNew>(Func<T, Task<TNew>> mapping) =>
@@ -139,10 +139,10 @@ public readonly partial struct Result<T>
             : new(Error);
 
     /// <summary>
-    /// Maps the value of the result to a new result using an asynchronous mapping function,
+    /// Maps the ok value of the result to a new result using an asynchronous mapping function,
     /// or does nothing if the result is an error.
     /// </summary>
-    /// <param name="mapping">The function used to map the value to a new result.</param>
+    /// <param name="mapping">The function used to map the ok value to a new result.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
     /// <returns>A result which is either the mapped result
     /// or a new result containing the error of the original result.</returns>
@@ -153,14 +153,14 @@ public readonly partial struct Result<T>
             : new(Error);
 
     /// <summary>
-    /// Tries to map the value of the result using an asynchronous mapping function,
+    /// Tries to map the ok value of the result using an asynchronous mapping function,
     /// or does nothing if the result is an error.
     /// If the mapping function throws an exception, the exception will be returned wrapped in an
     /// <see cref="ExceptionError"/>.
     /// </summary>
-    /// <param name="mapping">The function used to map the value.</param>
+    /// <param name="mapping">The function used to map the ok value.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
-    /// <returns>A new result containing either the mapped value,
+    /// <returns>A new result containing either the mapped ok value,
     /// the exception thrown by <paramref name="mapping"/> wrapped in an <see cref="ExceptionError"/>,
     /// or the error of the original result.</returns>
     [Pure]
@@ -180,12 +180,12 @@ public readonly partial struct Result<T>
     }
 
     /// <summary>
-    /// Tries to map the value of the result to a new result using an asynchronous mapping function,
+    /// Tries to map the ok value of the result to a new result using an asynchronous mapping function,
     /// or does nothing if the result is an error.
     /// If the mapping function throws an exception, the exception will be returned wrapped in an
     /// <see cref="ExceptionError"/>.
     /// </summary>
-    /// <param name="mapping">The function used to map the value to a new result.</param>
+    /// <param name="mapping">The function used to map the ok value to a new result.</param>
     /// <typeparam name="TNew">The type of the new value.</typeparam>
     /// <returns>A result which is either the mapped result,
     /// the exception thrown by <paramref name="mapping"/> wrapped in an <see cref="ExceptionError"/>,

--- a/src/Rascal/Result_Matching.cs
+++ b/src/Rascal/Result_Matching.cs
@@ -19,7 +19,7 @@ public readonly partial struct Result<T>
     /// on the value or error of the result.</returns>
     [Pure]
     public TResult Match<TResult>(Func<T, TResult> ifValue, Func<Error, TResult> ifError) =>
-        HasValue
+        IsOk
             ? ifValue(value!)
             : ifError(Error);
 
@@ -34,7 +34,7 @@ public readonly partial struct Result<T>
     /// result's error if it does not contain a value.</param>
     public void Switch(Action<T> ifValue, Action<Error> ifError)
     {
-        if (HasValue) ifValue(value!);
+        if (IsOk) ifValue(value!);
         else ifError(Error);
     }
 
@@ -51,7 +51,7 @@ public readonly partial struct Result<T>
 #endif
     {
         value = this.value!;
-        return HasValue;
+        return IsOk;
     }
 
     /// <summary>
@@ -68,11 +68,11 @@ public readonly partial struct Result<T>
 #endif
     {
         value = this.value!;
-        error = !HasValue
+        error = !IsOk
             ? Error
             : null!;
         
-        return HasValue;
+        return IsOk;
     }
 
     /// <summary>
@@ -87,11 +87,11 @@ public readonly partial struct Result<T>
     public bool TryGetError(out Error error)
 #endif
     {
-        error = !HasValue
+        error = !IsOk
             ? Error
             : null!;
 
-        return !HasValue;
+        return !IsOk;
     }
 
     /// <summary>
@@ -107,12 +107,12 @@ public readonly partial struct Result<T>
     public bool TryGetError(out Error error, out T value)
 #endif
     {
-        error = !HasValue
+        error = !IsOk
             ? Error
             : null!;
         value = this.value!;
 
-        return !HasValue;
+        return !IsOk;
     }
 
     /// <summary>
@@ -121,7 +121,7 @@ public readonly partial struct Result<T>
     /// </summary>
     [Pure]
     public T? GetValueOrDefault() =>
-        HasValue
+        IsOk
             ? value
             : default;
 
@@ -132,7 +132,7 @@ public readonly partial struct Result<T>
     /// <param name="default">The default value to return if the result does not contain a value.</param>
     [Pure]
     public T GetValueOrDefault(T @default) =>
-        HasValue
+        IsOk
             ? value!
             : @default;
 
@@ -144,7 +144,7 @@ public readonly partial struct Result<T>
     /// if the result does not contain a value.</param>
     [Pure]
     public T GetValueOrDefault(Func<T> getDefault) =>
-        HasValue
+        IsOk
             ? value!
             : getDefault();
 
@@ -161,7 +161,7 @@ public readonly partial struct Result<T>
     /// <exception cref="UnwrapException">The result does not contain a value.</exception>
     [Pure]
     public T Unwrap() =>
-        HasValue
+        IsOk
             ? value!
             : throw new UnwrapException();
 
@@ -185,7 +185,7 @@ public readonly partial struct Result<T>
     /// <exception cref="UnwrapException">The result does not contain a value.</exception>
     [Pure]
     public T Expect(string error) =>
-        HasValue
+        IsOk
             ? value!
             : throw new UnwrapException(error);
 }

--- a/src/Rascal/Result_Matching.cs
+++ b/src/Rascal/Result_Matching.cs
@@ -5,18 +5,16 @@ namespace Rascal;
 public readonly partial struct Result<T>
 {
     /// <summary>
-    /// Matches over the value or error of the result and returns another value.
+    /// Matches over the ok value or error of the result and returns another value.
     /// Can be conceptualized as an exhaustive <c>switch</c> expression matching
     /// all possible values of the type.
     /// </summary>
     /// <typeparam name="TResult">The type to return from the match.</typeparam>
-    /// <param name="ifValue">The function to apply to the
-    /// value of the result if it does contain a value.</param>
-    /// <param name="ifError">The function to apply to the
-    /// result's error if it does not contain a value.</param>
+    /// <param name="ifValue">The function to apply to the ok value of the result if the result is ok.</param>
+    /// <param name="ifError">The function to apply to the result's error if the result is an error.</param>
     /// <returns>The result of applying either
     /// <paramref name="ifValue"/> or <paramref name="ifError"/>
-    /// on the value or error of the result.</returns>
+    /// on the ok value or error of the result.</returns>
     [Pure]
     public TResult Match<TResult>(Func<T, TResult> ifValue, Func<Error, TResult> ifError) =>
         IsOk
@@ -24,14 +22,11 @@ public readonly partial struct Result<T>
             : ifError(Error);
 
     /// <summary>
-    /// Matches over the value or error of the result and invokes an effectful action onto the value or error.
-    /// Can be conceptualized as an exhaustive <c>switch</c> statement matching
-    /// all possible values of the type.
+    /// Matches over the ok value or error of the result and invokes an effect-ful action onto the ok value or error.
+    /// Can be conceptualized as an exhaustive <c>switch</c> statement matching all possible values of the type.
     /// </summary>
-    /// <param name="ifValue">The function to call with the
-    /// value of the result if it does contain a value.</param>
-    /// <param name="ifError">The function to call with the
-    /// result's error if it does not contain a value.</param>
+    /// <param name="ifValue">The function to call with the ok value of the result if the result is ok.</param>
+    /// <param name="ifError">The function to call with the result's error if the result is an error.</param>
     public void Switch(Action<T> ifValue, Action<Error> ifError)
     {
         if (IsOk) ifValue(value!);
@@ -39,10 +34,10 @@ public readonly partial struct Result<T>
     }
 
     /// <summary>
-    /// Tries to get the value from the result.
+    /// Tries to get the ok value from the result.
     /// </summary>
-    /// <param name="value">The value of the result.</param>
-    /// <returns>Whether the result contains a value.</returns>
+    /// <param name="value">The ok value of the result.</param>
+    /// <returns>Whether the result is ok.</returns>
     [Pure]
 #if NETCOREAPP
     public bool TryGetValue([MaybeNullWhen(false)] out T value)
@@ -55,11 +50,11 @@ public readonly partial struct Result<T>
     }
 
     /// <summary>
-    /// Tries to get the value from the result.
+    /// Tries to get the ok value from the result.
     /// </summary>
-    /// <param name="value">The value of the result.</param>
+    /// <param name="value">The ok value of the result.</param>
     /// <param name="error">The error of the result.</param>
-    /// <returns>Whether the result contains a value.</returns>
+    /// <returns>Whether the result is ok.</returns>
     [Pure]
 #if NETCOREAPP
     public bool TryGetValue([MaybeNullWhen(false)] out T value, [MaybeNullWhen(true)] out Error error)
@@ -79,7 +74,7 @@ public readonly partial struct Result<T>
     /// Tries to get an error from the result.
     /// </summary>
     /// <param name="error">The error of the result.</param>
-    /// <returns>Whether the result contains an error.</returns>
+    /// <returns>Whether the result is an error.</returns>
     [Pure]
 #if NETCOREAPP
     public bool TryGetError([MaybeNullWhen(false)] out Error error)
@@ -98,8 +93,8 @@ public readonly partial struct Result<T>
     /// Tries to get an error from the result.
     /// </summary>
     /// <param name="error">The error of the result.</param>
-    /// <param name="value">The value of the result.</param>
-    /// <returns>Whether the result contains an error.</returns>
+    /// <param name="value">The ok value of the result.</param>
+    /// <returns>Whether the result is an error.</returns>
     [Pure]
 #if NETCOREAPP
     public bool TryGetError([MaybeNullWhen(false)] out Error error, [MaybeNullWhen(true)] out T value)
@@ -116,8 +111,7 @@ public readonly partial struct Result<T>
     }
 
     /// <summary>
-    /// Gets the value within the result,
-    /// or <see langword="default"/> if the result does not contain a value.
+    /// Gets the ok value of the result, or <see langword="default"/> if the result is not ok.
     /// </summary>
     [Pure]
     public T? GetValueOrDefault() =>
@@ -126,10 +120,9 @@ public readonly partial struct Result<T>
             : default;
 
     /// <summary>
-    /// Gets the value within the result,
-    /// or a default value if the result does not contain a value.
+    /// Gets the ok value of the result, or a default value if the result is not ok.
     /// </summary>
-    /// <param name="default">The default value to return if the result does not contain a value.</param>
+    /// <param name="default">The default value to return if the result is not ok.</param>
     [Pure]
     public T GetValueOrDefault(T @default) =>
         IsOk
@@ -137,11 +130,10 @@ public readonly partial struct Result<T>
             : @default;
 
     /// <summary>
-    /// Gets the value within the result,
-    /// or a default value if the result does not contain a value.
+    /// Gets the ok value of the result, or a default value if the result is not ok.
     /// </summary>
     /// <param name="getDefault">A function to get a default value to return
-    /// if the result does not contain a value.</param>
+    /// if the result is not ok.</param>
     [Pure]
     public T GetValueOrDefault(Func<T> getDefault) =>
         IsOk
@@ -149,16 +141,16 @@ public readonly partial struct Result<T>
             : getDefault();
 
     /// <summary>
-    /// Unwraps the value in the result.
-    /// Throws an <see cref="UnwrapException"/> if the result does not contain a value.
+    /// Unwraps the ok value of the result.
+    /// Throws an <see cref="UnwrapException"/> if the result is not ok.
     /// </summary>
     /// <remarks>
     /// This API is <b>unsafe</b> in the sense that it might intentionally throw an exception.
     /// Please only use this API if the caller knows without a reasonable shadow of a doubt
     /// that this operation is safe, or that an exception is acceptable to be thrown.
     /// </remarks>
-    /// <returns>The value in the result.</returns>
-    /// <exception cref="UnwrapException">The result does not contain a value.</exception>
+    /// <returns>The ok value of the result.</returns>
+    /// <exception cref="UnwrapException">The result is not ok.</exception>
     [Pure]
     public T Unwrap() =>
         IsOk
@@ -171,18 +163,18 @@ public readonly partial struct Result<T>
         result.Unwrap();
 
     /// <summary>
-    /// Expects the result to contain a value, throwing an <see cref="UnwrapException"/>
-    /// with a specified message if the result does not contain a value.
+    /// Expects the result to be ok, throwing an <see cref="UnwrapException"/>
+    /// with a specified message if the result is not ok.
     /// </summary>
     /// <param name="error">The message to construct the <see cref="UnwrapException"/>
-    /// to throw using if the result does not contain a value.</param>
+    /// to throw using if the result is not ok.</param>
     /// <remarks>
     /// This API is <b>unsafe</b> in the sense that it might intentionally throw an exception.
     /// Please only use this API if the caller knows without a reasonable shadow of a doubt
     /// that this operation is safe, or that an exception is acceptable to be thrown.
     /// </remarks>
-    /// <returns>The value in the result.</returns>
-    /// <exception cref="UnwrapException">The result does not contain a value.</exception>
+    /// <returns>The ok value of the result.</returns>
+    /// <exception cref="UnwrapException">The result is not ok.</exception>
     [Pure]
     public T Expect(string error) =>
         IsOk

--- a/src/Rascal/Result_Utility.cs
+++ b/src/Rascal/Result_Utility.cs
@@ -24,7 +24,7 @@ public readonly partial struct Result<T>
     /// that error, or both errors if both results contain errors.</returns>
     [Pure]
     public Result<(T first, TOther second)> Combine<TOther>(Result<TOther> other) =>
-        (HasValue, other.HasValue) switch
+        (IsOk, other.IsOk) switch
     {
         (true, true) => new((value!, other.value!)),
         (false, true) => new(Error),
@@ -43,7 +43,7 @@ public readonly partial struct Result<T>
     [Pure]
     public Result<TDerived> ToType<TDerived>(string? error = null)
         where TDerived : T =>
-        HasValue
+        IsOk
             ? value is TDerived derived
                 ? new(derived)
                 : new(new ValidationError(
@@ -87,7 +87,7 @@ public readonly partial struct Result<T>
         Func<T, bool> predicate,
         Func<T, Error>? getError = null) =>
 #endif
-        HasValue
+        IsOk
             ? predicate(value!)
                 ? this
                 : new(getError?.Invoke(value!)
@@ -137,7 +137,7 @@ public readonly partial struct Result<T>
     /// or no values at all if the result does not contain a value</returns>
     [Pure]
     public IEnumerable<T> ToEnumerable() =>
-        HasValue
+        IsOk
             ? [value!]
             : [];
 

--- a/src/Rascal/Result_Utility.cs
+++ b/src/Rascal/Result_Utility.cs
@@ -6,7 +6,7 @@ namespace Rascal;
 public readonly partial struct Result<T>
 {
     /// <summary>
-    /// Implicitly constructs a result from a value.
+    /// Implicitly constructs a result from an ok value.
     /// </summary>
     /// <param name="value">The value to construct the result from.</param>
     [Pure]
@@ -16,12 +16,12 @@ public readonly partial struct Result<T>
     /// <summary>
     /// Combines the result with another result.
     /// </summary>
-    /// <typeparam name="TOther">The type of the value in the other result.</typeparam>
+    /// <typeparam name="TOther">The type of the ok value in the other result.</typeparam>
     /// <param name="other">The result to combine the current result with.</param>
-    /// <returns>A result containing a tuple of the value
-    /// of the current result and the value of <paramref name="other"/>.
-    /// If either of the results do contain an error, returns a result containing
-    /// that error, or both errors if both results contain errors.</returns>
+    /// <returns>A result containing a tuple of the ok value of the current result
+    /// and the ok value of <paramref name="other"/>.
+    /// If either of the results are errors, returns a result containing
+    /// that error, or both errors if both results are errors.</returns>
     [Pure]
     public Result<(T first, TOther second)> Combine<TOther>(Result<TOther> other) =>
         (IsOk, other.IsOk) switch
@@ -33,13 +33,15 @@ public readonly partial struct Result<T>
     };
 
     /// <summary>
-    /// Tries to convert the result value to another type.
+    /// Tries to convert the ok value of the result to another type.
     /// </summary>
     /// <typeparam name="TDerived">The type derived from <typeparamref name="T"/>
-    /// to which to try convert the value.</typeparam>
-    /// <param name="error">The error to return </param>
-    /// <returns>A result which contains the current result's value converted to
-    /// <typeparamref name="TDerived"/>, </returns>
+    /// to which to try convert the ok value.</typeparam>
+    /// <param name="error">The error to return
+    /// if the ok value cannot be converted to <typeparamref name="TDerived"/>.</param>
+    /// <returns>A result which contains the ok value converted to <typeparamref name="TDerived"/>,
+    /// <paramref name="error"/> if the ok value cannot be converted to <typeparamref name="TDerived"/>,
+    /// or the error of the result if it is an error.</returns>
     [Pure]
     public Result<TDerived> ToType<TDerived>(string? error = null)
         where TDerived : T =>
@@ -53,18 +55,18 @@ public readonly partial struct Result<T>
 
 #if NETCOREAPP
     /// <summary>
-    /// Checks whether the value in the result matches a predicate,
+    /// Checks whether the ok value of the result matches a predicate,
     /// and if not replaces the value with an error.
     /// </summary>
-    /// <param name="predicate">The predicate to match the value against.</param>
+    /// <param name="predicate">The predicate to match the ok value against.</param>
     /// <param name="getError">A function to produce an error
-    /// if the value doesn't match the predicate.</param>
+    /// if the ok value doesn't match the predicate.</param>
     /// <param name="expr">The caller argument expression for <paramref name="predicate"/>.
     /// Should not be specified explicitly, instead letting the compiler fill it in.</param>
-    /// <returns>A result which contains the value of the original result
-    /// if the value matches <paramref name="predicate"/>, otherwise an
+    /// <returns>A result which contains the ok value of the original result
+    /// if said value matches <paramref name="predicate"/>, otherwise an
     /// error produced by <paramref name="getError"/>.
-    /// If the original result does not contain a value, that result will be returned.</returns>
+    /// If the original result is an error, that error will be returned.</returns>
     [Pure]
     public Result<T> Validate(
         Func<T, bool> predicate,
@@ -72,16 +74,16 @@ public readonly partial struct Result<T>
         [CallerArgumentExpression(nameof(predicate))] string expr = "") =>
 #else
     /// <summary>
-    /// Checks whether the value in the result matches a predicate,
+    /// Checks whether the ok value in the result matches a predicate,
     /// and if not replaces the value with an error.
     /// </summary>
-    /// <param name="predicate">The predicate to match the value against.</param>
+    /// <param name="predicate">The predicate to match the ok value against.</param>
     /// <param name="getError">A function to produce an error
-    /// if the value doesn't match the predicate.</param>
-    /// <returns>A result which contains the value of the original result
-    /// if the value matches <paramref name="predicate"/>, otherwise an
+    /// if the ok value doesn't match the predicate.</param>
+    /// <returns>A result which contains the ok value of the original result
+    /// if said value matches <paramref name="predicate"/>, otherwise an
     /// error produced by <paramref name="getError"/>.
-    /// If the original result does not contain a value, that result will be returned.</returns>
+    /// If the original result is an error, that error will be returned.</returns>
     [Pure]
     public Result<T> Validate(
         Func<T, bool> predicate,
@@ -100,15 +102,15 @@ public readonly partial struct Result<T>
 
 #if NETCOREAPP
     /// <summary>
-    /// Checks whether the value in the result matches a predicate,
+    /// Checks whether the ok value of the result matches a predicate,
     /// and if not replaces the value with an error.
     /// </summary>
-    /// <param name="predicate">The predicate to match the value against.</param>
+    /// <param name="predicate">The predicate to match the ok value against.</param>
     /// <param name="expr">The caller argument expression for <paramref name="predicate"/>.
     /// Should not be specified explicitly, instead letting the compiler fill it in.</param>
-    /// <returns>A result which contains the value of the original result
-    /// if the value matches <paramref name="predicate"/>, otherwise an error.
-    /// If the original result does not contain a value, that result will be returned.</returns>
+    /// <returns>A result which contains the ok value of the original result
+    /// if said value matches <paramref name="predicate"/>, otherwise an error.
+    /// If the original result is an error, that error will be returned.</returns>
     [Pure]
     public Result<T> Where(
         Func<T, bool> predicate,
@@ -116,13 +118,13 @@ public readonly partial struct Result<T>
         Validate(predicate, null, expr);
 #else
     /// <summary>
-    /// Checks whether the value in the result matches a predicate,
+    /// Checks whether the ok value of the result matches a predicate,
     /// and if not replaces the value with an error.
     /// </summary>
-    /// <param name="predicate">The predicate to match the value against.</param>
-    /// <returns>A result which contains the value of the original result
-    /// if the value matches <paramref name="predicate"/>, otherwise an error.
-    /// If the original result does not contain a value, that result will be returned.</returns>
+    /// <param name="predicate">The predicate to match the ok value against.</param>
+    /// <returns>A result which contains the ok value of the original result
+    /// if said value matches <paramref name="predicate"/>, otherwise an error.
+    /// If the original result is an error, that error will be returned.</returns>
     [Pure]
     public Result<T> Where(
         Func<T, bool> predicate) =>
@@ -132,9 +134,8 @@ public readonly partial struct Result<T>
     /// <summary>
     /// Creates a <see cref="IEnumerable{T}"/> from the result.
     /// </summary>
-    /// <returns>A <see cref="IEnumerable{T}"/>
-    /// containing either only the value of the result,
-    /// or no values at all if the result does not contain a value</returns>
+    /// <returns>A <see cref="IEnumerable{T}"/> containing either only the ok value of the result,
+    /// or no values at all if the result is an error.</returns>
     [Pure]
     public IEnumerable<T> ToEnumerable() =>
         IsOk
@@ -142,10 +143,10 @@ public readonly partial struct Result<T>
             : [];
 
     /// <summary>
-    /// Gets an immutable reference to the value of the result.
+    /// Gets an immutable reference to the ok value of the result.
     /// </summary>
-    /// <returns>An immutable reference to the result's value.
-    /// The value might be <see langword="default"/> if the result does not contain a value.</returns>
+    /// <returns>An immutable reference to the ok value.
+    /// The value of the reference might be <see langword="default"/> if the result is an error.</returns>
     [UnscopedRef]
     [Pure]
     public ref readonly T? AsRef() =>

--- a/src/Rascal/UnwrapException.cs
+++ b/src/Rascal/UnwrapException.cs
@@ -1,8 +1,7 @@
 namespace Rascal;
 
 /// <summary>
-/// The exception thrown when a <see cref="Result{T}"/>
-/// is attempted to be unwraped but does not contain a value.
+/// The exception thrown when a <see cref="Result{T}"/> is attempted to be unwrapped but is an error.
 /// </summary>
 public sealed class UnwrapException : Exception
 {


### PR DESCRIPTION
Rename `Result<T>.HasValue` to `IsOk` to better align intent and nomenclature, and rewrite a lot of documentation to reflect this. Also add `Result<T>.IsError`.